### PR TITLE
Add Day 2 counter example

### DIFF
--- a/day2-counter.html
+++ b/day2-counter.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Day 2 — Counter</title>
+  <style>
+    :root {
+      --bg: #f7f7f8;
+      --panel: #ffffff;
+      --text: #101114;
+      --muted: #6b7280;
+      --brand: #2563eb;
+      --brand-hover: #1d4ed8;
+      --danger: #ef4444;
+      --shadow: 0 10px 28px rgba(0,0,0,0.08);
+      --radius: 14px;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      background: linear-gradient(180deg, var(--bg), #ececf1 80%);
+      color: var(--text);
+      display: grid;
+      place-items: center;
+    }
+    .wrap {
+      width: min(560px, 92vw);
+      background: var(--panel);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: 28px;
+    }
+    .header {
+      display: flex; align-items: baseline; justify-content: space-between;
+      margin-bottom: 18px;
+    }
+    h1 { font-size: 18px; margin: 0; }
+    .hint { color: var(--muted); font-size: 13px; }
+    .value {
+      text-align: center;
+      font-size: clamp(40px, 10vw, 64px);
+      font-weight: 700;
+      line-height: 1.1;
+      padding: 12px 0 18px;
+    }
+    .controls {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+    button {
+      appearance: none;
+      border: 0;
+      background: var(--brand);
+      color: white;
+      padding: 12px 16px;
+      border-radius: 10px;
+      font-size: 16px;
+      cursor: pointer;
+      transition: transform .06s ease, background-color .15s ease, opacity .15s ease;
+    }
+    button:hover { background: var(--brand-hover); }
+    button:active { transform: translateY(1px); }
+    button:focus-visible { outline: 0; box-shadow: 0 0 0 3px rgba(37, 99, 235, .35); }
+    button.secondary { background: #111827; }
+    button.secondary:hover { opacity: .9; }
+    button.danger { background: var(--danger); }
+    button[disabled] { opacity: .45; cursor: not-allowed; }
+    .row {
+      display: flex; gap: 12px; align-items: center; justify-content: center; margin-top: 14px;
+    }
+    input[type="number"] {
+      width: 90px; padding: 10px 12px; border-radius: 10px; border: 1px solid #d1d5db; font-size: 14px;
+    }
+    .sr-only {
+      position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="header">
+      <h1>Day 2 — Counter</h1>
+      <div class="hint">Shortcuts: + / − / r</div>
+    </div>
+
+    <div class="value" id="value" aria-live="polite">0</div>
+
+    <div class="controls">
+      <button id="decBtn" aria-label="Decrease">−</button>
+      <button id="incBtn" aria-label="Increase">+</button>
+      <button id="resetBtn" class="danger" aria-label="Reset">Reset</button>
+    </div>
+
+    <div class="row" aria-label="Step controls">
+      <label for="step" class="sr-only">Step</label>
+      <span class="hint">Step</span>
+      <input id="step" type="number" min="1" value="1" />
+      <button id="applyStep" class="secondary">Apply</button>
+    </div>
+  </div>
+
+  <script>
+    // ---- State (imperative) ----
+    let count = 0;
+    let step = 1;
+    const min = 0; // Prevent going negative to demo disabled state
+
+    // ---- DOM ----
+    const valueEl = document.getElementById('value');
+    const incBtn = document.getElementById('incBtn');
+    const decBtn = document.getElementById('decBtn');
+    const resetBtn = document.getElementById('resetBtn');
+    const stepInput = document.getElementById('step');
+    const applyStepBtn = document.getElementById('applyStep');
+
+    // ---- Render (manual) ----
+    function render() {
+      valueEl.textContent = String(count);
+      decBtn.disabled = count <= min;
+    }
+
+    // ---- Actions ----
+    function increment() {
+      count += step;
+      render();
+    }
+    function decrement() {
+      count = Math.max(min, count - step);
+      render();
+    }
+    function reset() {
+      count = 0;
+      render();
+    }
+    function applyStep() {
+      const next = parseInt(stepInput.value, 10);
+      if (!Number.isNaN(next) && next > 0) {
+        step = next;
+      }
+      stepInput.value = step;
+    }
+
+    // ---- Events ----
+    incBtn.addEventListener('click', increment);
+    decBtn.addEventListener('click', decrement);
+    resetBtn.addEventListener('click', reset);
+    applyStepBtn.addEventListener('click', applyStep);
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+      if (e.key === '+' || e.key === '=') increment();
+      if (e.key === '-' || e.key === '_') decrement();
+      if (e.key.toLowerCase() === 'r') reset();
+    });
+
+    // Initial render
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Day 2 counter page with controls for incrementing, decrementing, resetting and adjusting the step

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d3bcbd744832e9840f2f7e497bca2